### PR TITLE
use RSpec.current_example for RSpec 3.x

### DIFF
--- a/email_doc.gemspec
+++ b/email_doc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rspec"
+  spec.add_dependency "rspec", "~> 3.0"
   spec.add_dependency "activesupport"
   spec.add_dependency "actionmailer"
 

--- a/lib/email_doc.rb
+++ b/lib/email_doc.rb
@@ -12,7 +12,7 @@ module EmailDoc
   def self.included(base)
     RSpec.configuration.after(:each, email_doc: true) do
       mail = ActionMailer::Base.deliveries.last
-      EmailDoc.documents.append(self, mail)
+      EmailDoc.documents.append(self, mail, RSpec.current_example)
     end
 
     RSpec.configuration.after(:suite) do

--- a/lib/email_doc/document.rb
+++ b/lib/email_doc/document.rb
@@ -5,22 +5,22 @@ module EmailDoc
   class Document
     extend Forwardable
 
-    attr_reader :mail, :context
+    attr_reader :mail, :context, :ex
 
     def_delegators :mail, :subject, :from, :to, :reply_to, :body
     def_delegators :context, :described_class
-    def_delegators :example, :description
 
-    def initialize(context, mail)
+    def initialize(context, mail, ex)
       @context = context
       @mail    = mail
+      @ex      = ex
     end
 
     def render
       ERB.new(<<-MD_END).result(binding)
 # #{described_class}
 
-## #{RSpec.current_example.description}
+## #{ex.description}
 
 ```
     From: #{from}
@@ -38,7 +38,7 @@ MD_END
     def pathname
       @pathname ||= begin
         dir  = './doc/mail/'
-        path = RSpec.current_example.file_path.gsub(%r<\./spec/mailers/(.+)_spec\.rb>, '\1.md')
+        path = ex.file_path.gsub(%r<\./spec/mailers/(.+)_spec\.rb>, '\1.md')
         Pathname.new(dir + path)
       end
     end

--- a/lib/email_doc/document.rb
+++ b/lib/email_doc/document.rb
@@ -8,7 +8,7 @@ module EmailDoc
     attr_reader :mail, :context
 
     def_delegators :mail, :subject, :from, :to, :reply_to, :body
-    def_delegators :context, :described_class, :example
+    def_delegators :context, :described_class
     def_delegators :example, :description
 
     def initialize(context, mail)
@@ -20,7 +20,7 @@ module EmailDoc
       ERB.new(<<-MD_END).result(binding)
 # #{described_class}
 
-## #{description}
+## #{RSpec.current_example.description}
 
 ```
     From: #{from}
@@ -38,7 +38,7 @@ MD_END
     def pathname
       @pathname ||= begin
         dir  = './doc/mail/'
-        path = @context.example.file_path.gsub(%r<\./spec/mailers/(.+)_spec\.rb>, '\1.md')
+        path = RSpec.current_example.file_path.gsub(%r<\./spec/mailers/(.+)_spec\.rb>, '\1.md')
         Pathname.new(dir + path)
       end
     end

--- a/lib/email_doc/documents.rb
+++ b/lib/email_doc/documents.rb
@@ -6,8 +6,8 @@ module EmailDoc
       @table = Hash.new {|table, key| table[key] = []}
     end
  
-    def append(context, mail)
-      document = EmailDoc::Document.new(context.clone, mail.clone)
+    def append(context, mail, example)
+      document = EmailDoc::Document.new(context.clone, mail.clone, example.clone)
       @table[document.pathname] << document
     end
  

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,2 +1,3 @@
 require 'rspec'
 require 'email_doc'
+require 'active_support/rescuable'

--- a/spec/lib/email_doc/document_spec.rb
+++ b/spec/lib/email_doc/document_spec.rb
@@ -24,7 +24,7 @@ describe EmailDoc::Document do
     it 'should render document' do
       document_patterns = [
         %r<# #{described_class}>,
-        %r<## #{example.description}>,
+        %r<## #{RSpec.current_example.description}>,
         %r<To: \["#{to}"\]>,
         %r<From: \["from@example.org"\]>,
         %r<Reply to: \["noreply@example.org"\]>,

--- a/spec/lib/email_doc/document_spec.rb
+++ b/spec/lib/email_doc/document_spec.rb
@@ -18,13 +18,15 @@ describe EmailDoc::Document do
 
   let(:mail) { mailer_class.welcome(to) }
 
+  let(:ex) { RSpec.current_example }
+
   describe '#render' do
-    subject { described_class.new(self, mail).render }
+    subject { described_class.new(self, mail, ex).render }
 
     it 'should render document' do
       document_patterns = [
         %r<# #{described_class}>,
-        %r<## #{RSpec.current_example.description}>,
+        %r<## #{ex.description}>,
         %r<To: \["#{to}"\]>,
         %r<From: \["from@example.org"\]>,
         %r<Reply to: \["noreply@example.org"\]>,


### PR DESCRIPTION
@mizoR Hello. 😃 
`RSpec::Core::ExampleGroup#example` is deprecated, so I remove `example` and I added `RSpec.current_example`. Thank you.

The following error message appears.

``` sh
# Run `bundle exec rspec`.
F

Failures:

  1) EmailDoc::Document#render should render document
     Failure/Error: %r<## #{example.description}>,
       `example` is not available from within an example (e.g. an `it` block) or from constructs that run in the scope of an example (e.g. `before`, `let`, etc). It is only available on an example group (e.g. a `describe` or `context` block).
     # ./spec/lib/email_doc/document_spec.rb:27:in `block (3 levels) in <top (required)>'

Finished in 0.00075 seconds (files took 0.27196 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/email_doc/document_spec.rb:24 # EmailDoc::Document#render should render document
```
